### PR TITLE
Allow mutation of arguments through composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A universal mocking class for Apex, built using the [Apex Stub API](https://deve
   UniversalMocker mockInstance = UniversalMocker.mock(AccountDBService.class);
   ```
 
-- Set mock values you want to return for each method. 
+- Set the mock values you want to return for each method. 
 
   ```java
   mockInstance.when('getOneAccount').thenReturn(mockAccount);
@@ -77,9 +77,12 @@ complete test method [here](./force-app/main/default/classes/example/AccountDoma
   mockInstance.when('doInsert').mutateWith(dmlMutatorInstance).thenReturnVoid();
 ```
 
+**Note**: You can call the `mutateWith` method any number of times in succession, with the same or different mutator instances,
+to create a chain of methods to mutate method arguments.
+
 ### Verification
 
-- Assert number of times a method was called.
+- Assert the number of times a method was called.
 
   ```java
   mockInstance.assertThat().method('getOneAccount').wasCalled(1,UniversalMocker.Times.EXACTLY);
@@ -103,6 +106,9 @@ complete test method [here](./force-app/main/default/classes/example/AccountDoma
   mockInstance.forMethod('doInsert').andInvocationNumber(0).getValueOf('acct');
   mockInstance.forMethod('doInsert').withParamTypes(new List<Type>{Account.class}).andInvocationNumber(0).getValueOf('acct');
   ```
+
+  **Note**: If you use `mutateWith` to mutate the original method arguments, the values returned here are the mutated
+  arguments and not the original method arguments.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A universal mocking class for Apex, built using the [Apex Stub API](https://deve
 - Create an instance of the class you want to mock.
 
   ```java
-  AccountDBService mockDBService = (AccountDBService)mock.createStub();
+  AccountDBService mockDBService = (AccountDBService)mockInstance.createStub();
   ```
 
 ### Verification

--- a/force-app/main/default/classes/UniversalMocker.cls
+++ b/force-app/main/default/classes/UniversalMocker.cls
@@ -134,6 +134,10 @@ public with sharing class UniversalMocker implements System.StubProvider {
     return this;
   }
 
+  public UniversalMocker thenReturnVoid() {
+    return this.thenReturn(null);
+  }
+
   public UniversalMocker thenReturn(Object returnObject) {
     if (!this.isInSetupMode) {
       throw new InvalidOperationException('Invalid order of operations. Must specify method name to mock/assert first');

--- a/force-app/main/default/classes/UniversalMocker.cls
+++ b/force-app/main/default/classes/UniversalMocker.cls
@@ -25,6 +25,9 @@ public with sharing class UniversalMocker implements System.StubProvider {
   private String INVALID_STATE_ERROR_MSG = 'Mocker object state is invalid for this operation. Please refer to the Readme';
   private String KEY_DELIMITER = '||';
 
+  //Map for storing mutators
+  Map<String, List<Mutator>> mutatorMap = new Map<String, List<Mutator>>();
+
   public enum Times {
     OR_LESS,
     OR_MORE,
@@ -115,6 +118,22 @@ public with sharing class UniversalMocker implements System.StubProvider {
     return this;
   }
 
+  public UniversalMocker mutateWith(Mutator mutatorInstance) {
+    if (!this.isInSetupMode) {
+      throw new InvalidOperationException('Invalid order of operations. Must specify method name to mock/assert first');
+    }
+    String key = this.getCurrentKey();
+    if (this.mutatorMap.containsKey(key)) {
+      this.mutatorMap.get(key).add(mutatorInstance);
+    } else {
+      this.mutatorMap.put(key, new List<Mutator>{ mutatorInstance });
+    }
+    if (!this.callCountsMap.containsKey(key)) {
+      this.callCountsMap.put(key, 0);
+    }
+    return this;
+  }
+
   public UniversalMocker thenReturn(Object returnObject) {
     if (!this.isInSetupMode) {
       throw new InvalidOperationException('Invalid order of operations. Must specify method name to mock/assert first');
@@ -173,6 +192,13 @@ public with sharing class UniversalMocker implements System.StubProvider {
     this.saveArguments(listOfParamNames, listOfArgs, keyInUse);
 
     Object returnValue = this.mocksMap.get(keyInUse);
+
+    if (this.mutatorMap.containsKey(keyInUse)) {
+      for (Mutator m : this.mutatorMap.get(keyInUse)) {
+        m.mutate(stubbedObject, stubbedMethodName, listOfParamTypes, listOfArgs);
+      }
+    }
+
     if (returnValue instanceof Exception) {
       throw (Exception) returnValue;
     }
@@ -277,5 +303,9 @@ public with sharing class UniversalMocker implements System.StubProvider {
   }
 
   public class InvalidOperationException extends Exception {
+  }
+
+  public interface Mutator {
+    void mutate(Object stubbedObject, String stubbedMethodName, List<Type> listOfParamTypes, List<Object> listOfArgs);
   }
 }

--- a/force-app/main/default/classes/example/AccountDomainTest.cls
+++ b/force-app/main/default/classes/example/AccountDomainTest.cls
@@ -145,14 +145,13 @@ public with sharing class AccountDomainTest {
   @isTest
   public static void it_should_mutate_arguments() {
     String mockedMethodName = 'doInsert';
-
     String mockExceptionMessage = 'Mock exception';
 
     //setup
     UniversalMocker mock = UniversalMocker.mock(AccountDBService.class);
     UniversalMocker.Mutator dmlMutatorInstance = new DMLMutator();
 
-    mock.when(mockedMethodName).mutateWith(dmlMutatorInstance).thenReturn(null);
+    mock.when(mockedMethodName).mutateWith(dmlMutatorInstance).thenReturnVoid();
 
     AccountDBService mockService = (AccountDBService) mock.createStub();
     AccountDomain acctDomainInstance = new AccountDomain(mockService);

--- a/force-app/main/default/classes/example/AccountDomainTest.cls
+++ b/force-app/main/default/classes/example/AccountDomainTest.cls
@@ -143,6 +143,39 @@ public with sharing class AccountDomainTest {
   }
 
   @isTest
+  public static void it_should_mutate_arguments() {
+    String mockedMethodName = 'doInsert';
+
+    String mockExceptionMessage = 'Mock exception';
+
+    //setup
+    UniversalMocker mock = UniversalMocker.mock(AccountDBService.class);
+    UniversalMocker.Mutator dmlMutatorInstance = new DMLMutator();
+
+    mock.when(mockedMethodName).mutateWith(dmlMutatorInstance).thenReturn(null);
+
+    AccountDBService mockService = (AccountDBService) mock.createStub();
+    AccountDomain acctDomainInstance = new AccountDomain(mockService);
+
+    //test
+    Test.startTest();
+    boolean hasException = false;
+    try {
+      acctDomainInstance.createPublicAccount('Mock Account');
+    } catch (AuraHandledException ex) {
+      System.assertEquals(mockExceptionMessage, ex.getMessage());
+      hasException = true;
+    }
+    Test.stopTest();
+
+    //verify
+    mock.assertThat().method(mockedMethodName).wasCalled(1, UniversalMocker.TIMES.EXACTLY);
+    System.assert(!hasException, 'Mocked exception was not thrown');
+    Account acct = (Account) mock.forMethod('doInsert').getValueOf('acct');
+    System.assertNotEquals(null, acct.Id, 'Account Id is null after insert');
+  }
+
+  @isTest
   public static void dummy_test_for_db_service() {
     AccountDBService dbSvc = new AccountDBService();
     Account a = new Account(Name = 'Acme');
@@ -150,5 +183,19 @@ public with sharing class AccountDomainTest {
     dbSvc.getOneAccount();
     dbSvc.getMatchingAccounts(Id.valueOf('001000000000001'));
     dbSvc.getMatchingAccounts('Acme');
+  }
+
+  public class DMLMutator implements UniversalMocker.Mutator {
+    // Ideally, 'fakeCounter' should be a static variable and 'getFakeId' should be a static method in another top-level class.
+    private Integer fakeIdCounter = 1;
+    public String getFakeId(Schema.SObjectType objType) {
+      String result = String.valueOf(this.fakeIdCounter++);
+      return objType.getDescribe().getKeyPrefix() + '0'.repeat(12 - result.length()) + result;
+    }
+
+    public void mutate(Object stubbedObject, String stubbedMethodName, List<Type> listOfParamTypes, List<Object> listOfArgs) {
+      Account record = (Account) listOfArgs[0];
+      record.Id = this.getFakeId(Account.SObjectType);
+    }
   }
 }


### PR DESCRIPTION
Currently, UM only allows you to return a static value for a mocked method. However, there are cases where you want the mocked method to mutate the original arguments. DMLs are a great example, where you may want to add fake ids to your SObject records. This change provides a path for devs to do exactly that