### PR TITLE
Added shorter wasCalled(int) method

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,16 @@ to create a chain of methods to mutate method arguments.
 
 ### Verification
 
-- Assert the number of times a method was called.
+- Assert the exact number of times a method was called.
 
   ```java
-  mockInstance.assertThat().method('getOneAccount').wasCalled(1,UniversalMocker.Times.EXACTLY);
+  mockInstance.assertThat().method('getOneAccount').wasCalled(1);
+  mockInstance.assertThat().method('getOneAccount').wasCalled(2);
+  ```
+
+- Assert if the number of times a method was called was more or less than a given integer.
+
+  ```java
   mockInstance.assertThat().method('getOneAccount').wasCalled(1,UniversalMocker.Times.OR_MORE);
   mockInstance.assertThat().method('getOneAccount').wasCalled(1,UniversalMocker.Times.OR_LESS);
   ```

--- a/force-app/main/default/classes/UniversalMocker.cls
+++ b/force-app/main/default/classes/UniversalMocker.cls
@@ -138,7 +138,7 @@ public with sharing class UniversalMocker implements System.StubProvider {
     return this;
   }
 
-  public  void wasCalledOnce() {
+  public void wasCalledOnce() {
     wasCalled(1, UniversalMocker.Times.EXACTLY);
   }
 

--- a/force-app/main/default/classes/UniversalMocker.cls
+++ b/force-app/main/default/classes/UniversalMocker.cls
@@ -138,8 +138,8 @@ public with sharing class UniversalMocker implements System.StubProvider {
     return this;
   }
 
-  public void wasCalledOnce() {
-    wasCalled(1, UniversalMocker.Times.EXACTLY);
+  public void wasCalled(Integer expectedCallCount) {
+    wasCalled(expectedCallCount, UniversalMocker.Times.EXACTLY);
   }
 
   public void wasCalled(Integer expectedCallCount, Times assertTypeValue) {

--- a/force-app/main/default/classes/UniversalMocker.cls
+++ b/force-app/main/default/classes/UniversalMocker.cls
@@ -138,6 +138,10 @@ public with sharing class UniversalMocker implements System.StubProvider {
     return this;
   }
 
+  public  void wasCalledOnce() {
+    wasCalled(1, UniversalMocker.Times.EXACTLY);
+  }
+
   public void wasCalled(Integer expectedCallCount, Times assertTypeValue) {
     if (!this.isInAssertMode) {
       throw new InvalidOperationException('Invalid order of operations. Method called without calling assertThat first');

--- a/force-app/main/default/classes/example/AccountDomainTest.cls
+++ b/force-app/main/default/classes/example/AccountDomainTest.cls
@@ -26,8 +26,7 @@ public with sharing class AccountDomainTest {
 
     //verify
     system.assertEquals(mockAccount.Name, accountDetail.Name);
-    mockService.assertThat().method(mockedMethodName).wasCalled(1, UniversalMocker.Times.EXACTLY);
-    mockService.assertThat().method(mockedMethodName).wasCalledOnce(); // convenience method for most common verification
+    mockService.assertThat().method(mockedMethodName).wasCalled(1);
   }
 
   @isTest
@@ -65,7 +64,7 @@ public with sharing class AccountDomainTest {
     system.assertEquals(mockAccount.Name, accountDetail.Name);
     mockService.assertThat().method(mockedMethodName).wasCalled(1, UniversalMocker.Times.OR_MORE);
     mockService.assertThat().method(mockedMethodName).wasCalled(2, UniversalMocker.Times.OR_MORE);
-    mockService.assertThat().method(mockedMethodName).wasCalled(2, UniversalMocker.Times.EXACTLY);
+    mockService.assertThat().method(mockedMethodName).wasCalled(2);
     mockService.assertThat().method(mockedMethodName).wasCalled(2, UniversalMocker.Times.OR_LESS);
     mockService.assertThat().method(mockedMethodName).wasCalled(3, UniversalMocker.Times.OR_LESS);
     mockService.assertThat().method('mockedDummyMethod').wasNeverCalled();
@@ -90,8 +89,8 @@ public with sharing class AccountDomainTest {
     Test.stopTest();
 
     //verify
-    mockService.assertThat().method(mockedMethodName).withParamTypes(new List<Type>{ Id.class }).wasCalled(1, UniversalMocker.Times.EXACTLY);
-    mockService.assertThat().method(mockedMethodName).withParamTypes(new List<Type>{ String.class }).wasCalled(1, UniversalMocker.Times.EXACTLY);
+    mockService.assertThat().method(mockedMethodName).withParamTypes(new List<Type>{ Id.class }).wasCalled(1);
+    mockService.assertThat().method(mockedMethodName).withParamTypes(new List<Type>{ String.class }).wasCalled(1);
     Id accountIdParam = (Id) mockService.forMethod(mockedMethodName).andInvocationNumber(0).withParamTypes(new List<Type>{ Id.class }).getValueOf('accountId');
     String acctNameParam = (String) mockService.forMethod(mockedMethodName)
       .andInvocationNumber(0)
@@ -127,7 +126,7 @@ public with sharing class AccountDomainTest {
     Test.stopTest();
 
     //verify
-    mockService.assertThat().method(mockedMethodName).wasCalled(1, UniversalMocker.TIMES.EXACTLY);
+    mockService.assertThat().method(mockedMethodName).wasCalled(1);
     System.assert(hasException, 'Mocked exception was not thrown');
   }
 
@@ -152,7 +151,7 @@ public with sharing class AccountDomainTest {
     Test.stopTest();
 
     //verify
-    mockService.assertThat().method(mockedMethodName).wasCalled(1, UniversalMocker.TIMES.EXACTLY);
+    mockService.assertThat().method(mockedMethodName).wasCalled(1);
     System.assert(!hasException, 'Mocked exception was not thrown');
     Account acct = (Account) mockService.forMethod('doInsert').getValueOf('acct');
     System.assertNotEquals(null, acct.Id, 'Account Id is null after insert');

--- a/force-app/main/default/classes/example/AccountDomainTest.cls
+++ b/force-app/main/default/classes/example/AccountDomainTest.cls
@@ -27,6 +27,7 @@ public with sharing class AccountDomainTest {
     //verify
     system.assertEquals(mockAccount.Name, accountDetail.Name);
     mockService.assertThat().method(mockedMethodName).wasCalled(1, UniversalMocker.Times.EXACTLY);
+    mockService.assertThat().method(mockedMethodName).wasCalledOnce(); // convenience method for most common verification
   }
 
   @isTest


### PR DESCRIPTION
In my experience, verifying that a method was called one time will be the most often used combination of arguments, therefore added the convenience method.