### PR TITLE
Add support for async contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apex Universal Mocker
 
-A universal mocking class for Apex, built using the [Apex Stub API](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_testing_stub_api.htm), subject to all its limitations. The api design choices for this class have been driven by a desire to make mocking as simple as possible for developers to understand and implement. It favors fluency and readability above everything else. Consequently, trade-offs have been made such as the limitation noted towards the end of this Readme. 
+A universal mocking class for Apex, built using the [Apex Stub API](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_testing_stub_api.htm), subject to all its limitations. The api design choices for this class have been driven by a desire to make mocking as simple as possible for developers to understand and implement. It favors fluency and readability above everything else. Consequently, trade-offs have been made such as the limitation noted towards the end of this Readme.
 
 ## Installation
 
@@ -16,7 +16,7 @@ A universal mocking class for Apex, built using the [Apex Stub API](https://deve
   UniversalMocker mockInstance = UniversalMocker.mock(AccountDBService.class);
   ```
 
-- Set the mock values you want to return for each method. 
+- Set the mock values you want to return for each method.
 
   ```java
   mockInstance.when('getOneAccount').thenReturn(mockAccount);
@@ -27,7 +27,7 @@ A universal mocking class for Apex, built using the [Apex Stub API](https://deve
 ```java
   mockInstance.when('getOneAccount').withParamTypes(new List<Type>{Id.class})
               .thenReturn(mockAccount);
-  ```
+```
 
 - You can also set up a method to throw an exception
 
@@ -43,11 +43,11 @@ A universal mocking class for Apex, built using the [Apex Stub API](https://deve
 
 #### Mutating arguments
 
-There might be instances where you need to modify the original arguments passed into the function. A typical example 
+There might be instances where you need to modify the original arguments passed into the function. A typical example
 would be to set the `Id` field of records passed into a method responsible for inserting them.
 
 - Create a class that implements the `UniversalMocker.Mutator` interface. The interface has a single method `mutate`
-with the following signature. 
+  with the following signature.
 
 ```java
   void mutate(
@@ -67,11 +67,12 @@ Here's the method for setting fake ids on inserted records, in our example.
       record.Id = this.getFakeId(Account.SObjectType);
   }
 ```
-Check out the [AccountDomainTest](./force-app/main/default/classes/example/AccountDomainTest.cls#L187) class for the 
+
+Check out the [AccountDomainTest](./force-app/main/default/classes/example/AccountDomainTest.cls#L187) class for the
 full example.
 
-- Pass in an instance of your implementation of the `Mutator` class to mutate the method arguments. Check out the 
-complete test method [here](./force-app/main/default/classes/example/AccountDomainTest.cls#L146)
+- Pass in an instance of your implementation of the `Mutator` class to mutate the method arguments. Check out the
+  complete test method [here](./force-app/main/default/classes/example/AccountDomainTest.cls#L146)
 
 ```java
   mockInstance.when('doInsert').mutateWith(dmlMutatorInstance).thenReturnVoid();
@@ -96,14 +97,14 @@ to create a chain of methods to mutate method arguments.
   mockInstance.assertThat().method('getOneAccount').wasCalled(1,UniversalMocker.Times.OR_LESS);
   ```
 
-- Assert that a method was not called. This works both for methods that had mock return values set up before the test 
+- Assert that a method was not called. This works both for methods that had mock return values set up before the test
   and for ones that didn't.
 
   ```java
   mockInstance.assertThat().method('dummyMethod').wasNeverCalled();
   ```
 
-  Note that `mockInstance.assertThat().method('dummyMethod').wasCalled(0,UniversalMocker.Times.EXACTLY);` would only 
+  Note that `mockInstance.assertThat().method('dummyMethod').wasCalled(0,UniversalMocker.Times.EXACTLY);` would only
   work if you had a mock return value set up for `dummyMethod` before running the test.
 
 - Get the value of an argument passed into a method. Use `withParamTypes` for overloaded methods.
@@ -124,6 +125,7 @@ to create a chain of methods to mutate method arguments.
 3. If you use `withParamTypes` for setting up the mock, you need to use it for verification and fetching method arguments as well.
 4. It is highly recommended that you always verify the mocked method call counts to insulate against typos in method names being mocked and any future refactoring.
 5. The glaring limitation in the current version is the inability to mock methods with exact arguments, so this may not work if that's what you're looking to do.
+6. Although it is not recommended to test async behavior in unit tests since that is a platform feature, the library does support it.
 
 ## Contributions
 

--- a/force-app/main/default/classes/UniversalMocker.cls
+++ b/force-app/main/default/classes/UniversalMocker.cls
@@ -8,10 +8,17 @@
 */
 @isTest
 public with sharing class UniversalMocker implements System.StubProvider {
+  // Map of methodName+paramTypes -> map of (paramname,value) for each invocation
   private final Map<String, List<Map<String, Object>>> argumentsMap = new Map<String, List<Map<String, Object>>>();
   private final Type mockedClass;
   private final Map<String, Object> mocksMap = new Map<String, Object>();
   private final Map<String, Integer> callCountsMap = new Map<String, Integer>();
+
+  @TestVisible
+  private static final Map<String, UniversalMocker> uMockInstances = new Map<String, UniversalMocker>();
+
+  //even though the 'guid' we are generating is a long (using Crypto.getRandomLong), we keep this a string, to make it easier if we need to switch to an actual guid in the future, and it isn't really costing us anything
+  private String guid;
 
   private String currentMethodName;
   private String currentParamTypesString;
@@ -42,8 +49,11 @@ public with sharing class UniversalMocker implements System.StubProvider {
     OR_MORE,
     EXACTLY
   }
+
   public static UniversalMocker mock(Type mockedClass) {
-    return new UniversalMocker(mockedClass);
+    UniversalMocker uMock = new UniversalMocker(mockedClass);
+    uMockInstances.put(uMock.guid, uMock);
+    return uMock;
   }
 
   public Object createStub() {
@@ -178,6 +188,7 @@ public with sharing class UniversalMocker implements System.StubProvider {
     if (returnValue instanceof Exception) {
       throw (Exception) returnValue;
     }
+    this.copyState(); //for async calls, we store the current object instance in a static map so the state is preserved even after leaving the async context
     return returnValue;
   }
 
@@ -244,7 +255,8 @@ public with sharing class UniversalMocker implements System.StubProvider {
   private void wasCalled(Integer expectedCallCount, Times assertTypeValue) {
     this.expectedCallCount = expectedCallCount;
     String currentKey = this.getCurrentKey();
-    Integer actualCallCount = this.callCountsMap.get(currentKey);
+    //Integer actualCallCount = this.callCountsMap.get(currentKey);
+    Integer actualCallCount = this.getCallCountsMapInternal().get(currentKey);
     String methodName = this.currentMethodName;
     switch on assertTypeValue {
       when OR_LESS {
@@ -261,7 +273,7 @@ public with sharing class UniversalMocker implements System.StubProvider {
 
   private void wasNeverCalled() {
     String currentKey = this.getCurrentKey();
-    Integer actualCallCount = this.callCountsMap.get(currentKey);
+    Integer actualCallCount = this.getCallCountsMapInternal().get(currentKey);
     String methodName = this.currentMethodName;
     if (actualCallCount != null) {
       this.expectedCallCount = 0;
@@ -275,7 +287,7 @@ public with sharing class UniversalMocker implements System.StubProvider {
 
   private Object getValueOf(String paramName) {
     String theKey = this.getCurrentKey();
-    Map<String, Object> paramsMap = argumentsMap.get(theKey).get(this.forInvocationNumber);
+    Map<String, Object> paramsMap = this.getArgumentsMapInternal().get(theKey).get(this.forInvocationNumber);
     if (!paramsMap.containsKey(paramName.toLowerCase())) {
       throw new IllegalArgumentException(String.format('Param name {0} not found for the method {1}', new List<Object>{ paramName, this.currentMethodName }));
     }
@@ -285,7 +297,7 @@ public with sharing class UniversalMocker implements System.StubProvider {
 
   private Map<String, Object> getArgumentsMap() {
     String theKey = this.getCurrentKey();
-    Map<String, Object> returnValue = this.argumentsMap.get(theKey).get(this.forInvocationNumber);
+    Map<String, Object> returnValue = this.getArgumentsMapInternal().get(theKey).get(this.forInvocationNumber);
     return returnValue;
   }
 
@@ -336,9 +348,27 @@ public with sharing class UniversalMocker implements System.StubProvider {
     return String.format('Expected call count for method {0} is not {1} to the actual count', new List<String>{ methodName, comparison });
   }
 
+  private Map<String, Integer> getCallCountsMapInternal() {
+    return uMockInstances.get(this.guid).callCountsMap;
+  }
+
+  private Map<String, List<Map<String, Object>>> getArgumentsMapInternal() {
+    return uMockInstances.get(this.guid).argumentsMap;
+  }
+
+  private void copyState() {
+    uMockInstances.put(this.guid, this);
+  }
+
   private UniversalMocker(Type mockedClass) {
     this.mockedClass = mockedClass;
+    this.guid = this.getGUID();
     this.initInnerClassInstances();
+  }
+
+  private String getGUID() {
+    String guid = Crypto.getRandomLong() + ''; // since guid generation is expensive, we "settle" for this, as it generates unique values and is performant
+    return guid;
   }
 
   private void initInnerClassInstances() {

--- a/force-app/main/default/classes/example/AccountDomainTest.cls
+++ b/force-app/main/default/classes/example/AccountDomainTest.cls
@@ -1,4 +1,4 @@
-@isTest
+@IsTest
 public with sharing class AccountDomainTest {
   private static final UniversalMocker mockService;
   private static final AccountDBService mockServiceStub;
@@ -10,7 +10,7 @@ public with sharing class AccountDomainTest {
     sut = new AccountDomain(mockServiceStub);
   }
 
-  @isTest
+  @IsTest
   public static void it_should_return_one_account() {
     //setup
     String mockedMethodName = 'getOneAccount';
@@ -28,7 +28,7 @@ public with sharing class AccountDomainTest {
     mockService.assertThat().method(mockedMethodName).wasCalled(1);
   }
 
-  @isTest
+  @IsTest
   public static void it_should_create_a_public_account() {
     //setup
     String mockedMethodName = 'doInsert';
@@ -44,7 +44,7 @@ public with sharing class AccountDomainTest {
     system.assertEquals('Public', newAccount.Ownership);
   }
 
-  @isTest
+  @IsTest
   public static void it_should_verify_call_counts_correctly() {
     //setup
     String mockedMethodName = 'getOneAccount';
@@ -70,7 +70,7 @@ public with sharing class AccountDomainTest {
     mockService.assertThat().method('nonMockedDummyMethod').wasNeverCalled();
   }
 
-  @isTest
+  @IsTest
   public static void it_should_call_overloaded_methods_correctly() {
     //setup
     String mockedMethodName = 'getMatchingAccounts';
@@ -102,7 +102,7 @@ public with sharing class AccountDomainTest {
     System.assertEquals(acctTwo.Name, acctsWithMatchingName[0].Name);
   }
 
-  @isTest
+  @IsTest
   public static void it_should_throw_mock_exception() {
     //setup
     String mockedMethodName = 'doInsert';
@@ -129,7 +129,53 @@ public with sharing class AccountDomainTest {
     System.assert(hasException, 'Mocked exception was not thrown');
   }
 
-  @isTest
+  @IsTest
+  public static void it_should_generate_unique_guids() {
+    Integer numInstances = 20000;
+    for (Integer i = 0; i < numInstances; i++) {
+      UniversalMocker uMock = UniversalMocker.mock(AccountDBService.class);
+    }
+    System.assertEquals(numInstances + 1, UniversalMocker.uMockInstances.size(), 'We have collision in the generated guids'); //numInstances + 1 generated in the static block above
+  }
+
+  @IsTest
+  public static void it_should_track_call_counts_across_queueables() {
+    String mockedMethodName = 'doInsert';
+    String mockExceptionMessage = 'Mock exception';
+    UniversalMocker.Mutator dmlMutatorInstance = new DMLMutator();
+
+    mockService.when(mockedMethodName).mutateWith(dmlMutatorInstance).thenReturnVoid();
+    AccountsQueuable queueableSut = new AccountsQueuable(sut);
+
+    //test
+    Test.startTest();
+    System.enqueueJob(queueableSut);
+    Test.stopTest();
+
+    //verify
+    mockService.assertThat().method(mockedMethodName).wasCalled(1);
+    Account acct = (Account) mockService.forMethod(mockedMethodName).getValueOf('acct');
+    System.assertNotEquals(null, acct.Id, 'Account Id is null after insert');
+  }
+
+  @IsTest
+  public static void it_should_track_call_counts_with_batchables() {
+    String mockedMethodName = 'getOneAccount';
+    Account mockAccount = new Account(Name = 'Mock Account');
+    mockService.when(mockedMethodName).thenReturn(mockAccount);
+
+    AccountsBatch batchableSut = new AccountsBatch(sut);
+
+    //test
+    Test.startTest();
+    Database.executeBatch(batchableSut, 1);
+    Test.stopTest();
+
+    //verify
+    mockService.assertThat().method(mockedMethodName).wasCalled(1);
+  }
+
+  @IsTest
   public static void it_should_mutate_arguments() {
     //setup
     String mockedMethodName = 'doInsert';
@@ -156,7 +202,7 @@ public with sharing class AccountDomainTest {
     System.assertNotEquals(null, acct.Id, 'Account Id is null after insert');
   }
 
-  @isTest
+  @IsTest
   public static void dummy_test_for_db_service() {
     AccountDBService dbSvc = new AccountDBService();
     Account a = new Account(Name = 'Acme');

--- a/force-app/main/default/classes/example/AccountsBatch.cls
+++ b/force-app/main/default/classes/example/AccountsBatch.cls
@@ -1,0 +1,17 @@
+public class AccountsBatch implements Database.Batchable<Integer> {
+  AccountDomain acctDomain = null;
+  public AccountsBatch(AccountDomain acctDomain) {
+    this.acctDomain = acctDomain;
+  }
+
+  public Iterable<Integer> start(Database.BatchableContext bc) {
+    return new List<Integer>{ 1 };
+  }
+
+  public void execute(Database.BatchableContext bc, List<Integer> scope) {
+    acctDomain.getAccountDetail(); //calls AcctDBservice.getOneAccount
+  }
+
+  public void finish(Database.BatchableContext bc) {
+  }
+}

--- a/force-app/main/default/classes/example/AccountsBatch.cls-meta.xml
+++ b/force-app/main/default/classes/example/AccountsBatch.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/example/AccountsQueuable.cls
+++ b/force-app/main/default/classes/example/AccountsQueuable.cls
@@ -1,0 +1,10 @@
+public with sharing class AccountsQueuable implements Queueable {
+  AccountDomain acctDomainInstance = null;
+  public AccountsQueuable(AccountDomain acctDomain) {
+    this.acctDomainInstance = acctDomain;
+  }
+
+  public void execute(System.QueueableContext qc) {
+    this.acctDomainInstance.createPublicAccount('Test Account');
+  }
+}

--- a/force-app/main/default/classes/example/AccountsQueuable.cls-meta.xml
+++ b/force-app/main/default/classes/example/AccountsQueuable.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
In async calls, since the mock instance being used is a copy of the
original instance, the state is not preserved outside the async context.
This commit addresses the issue. We store a map of all Umock instances
in a static map, keyed by a guid, and copy the current instance to the map
after each method call. The subsequent verification methods uses the instance
stored in the static map instead of the current instance.

Fixes #16 