### PR TITLE
Enable Sequential Mocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # Salesforce cache
 .sfdx/
 .localdevserver/
+.sf/
 
 # LWC VSCode autocomplete
 **/lwc/jsconfig.json

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ A universal mocking class for Apex, built using the [Apex Stub API](https://deve
   mockInstance.when('getOneAccount').thenReturn(mockAccount);
   ```
 
+- Use the `isCalledForTheNthTime` method to define multiple return values for sequential execution of the same method.
+
+  ```java
+  mockInstance.when('checkIsValid').isCalledForTheNthTime(1).thenReturn(true);
+  mockInstance.when('checkIsValid').isCalledForTheNthTime(2).thenReturn(false);
+  ```
+
 - Use `withParamTypes` for overloaded methods.
 
 ```java

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ A universal mocking class for Apex, built using the [Apex Stub API](https://deve
 
 - Use `withParamTypes` for overloaded methods.
 
-```java
+  ```java
   mockInstance.when('getOneAccount').withParamTypes(new List<Type>{Id.class})
               .thenReturn(mockAccount);
-```
+  ```
 
 - You can also set up a method to throw an exception
 

--- a/force-app/main/default/classes/UniversalMocker.cls
+++ b/force-app/main/default/classes/UniversalMocker.cls
@@ -246,7 +246,7 @@ public with sharing class UniversalMocker implements System.StubProvider {
   }
 
   private void isCalledForTheNthTime(Integer n) {
-    if (n < 1) {
+    if (n == null || n < 1) {
       throw new IllegalArgumentException('`isCalledForTheNthTime` is only valid for n >= 1');
     }
     this.setResultsForCallingNTimes = true;

--- a/force-app/main/default/classes/UniversalMocker.cls
+++ b/force-app/main/default/classes/UniversalMocker.cls
@@ -8,10 +8,12 @@
 */
 @isTest
 public with sharing class UniversalMocker implements System.StubProvider {
+  public static final string MISSING_RETURN_VALUE_FOR_NTH_TIME_CALLING = 'Missing the return value definition for the nth time calling where n = {0}.';
+  
   // Map of methodName+paramTypes -> map of (paramname,value) for each invocation
   private final Map<String, List<Map<String, Object>>> argumentsMap = new Map<String, List<Map<String, Object>>>();
   private final Type mockedClass;
-  private final Map<String, Object> mocksMap = new Map<String, Object>();
+  private final Map<String, Map<Integer, Object>> mocksMap = new Map<String, Map<Integer, Object>>();
   private final Map<String, Integer> callCountsMap = new Map<String, Integer>();
 
   @TestVisible
@@ -24,6 +26,8 @@ public with sharing class UniversalMocker implements System.StubProvider {
   private String currentParamTypesString;
   private Integer expectedCallCount;
   private Integer forInvocationNumber = 0;
+  private Integer onTheNthTime = 1;
+  private boolean setResultsForCallingNTimes = false;
 
   private String KEY_DELIMITER = '||';
 
@@ -77,6 +81,10 @@ public with sharing class UniversalMocker implements System.StubProvider {
     }
     public void thenReturnVoid() {
       this.parent.thenReturnVoid();
+    }
+    public SetupMode_Midway isCalledForTheNthTime(Integer n) {
+      this.parent.isCalledForTheNthTime(n);
+      return this;
     }
     public void thenReturn(Object returnObject) {
       this.parent.thenReturn(returnObject);
@@ -175,9 +183,18 @@ public with sharing class UniversalMocker implements System.StubProvider {
   ) {
     String keyInUse = this.determineKeyToUseForCurrentStubbedMethod(stubbedMethodName, listOfParamTypes);
     this.incrementCallCount(keyInUse);
+    Integer currentCallCount = this.callCountsMap.get(keyInUse);
+    Integer countToUse = this.setResultsForCallingNTimes ? currentCallCount : 1;
+    if (this.setResultsForCallingNTimes) {
+      for (Integer i = 1; i <= countToUse; i++) {
+        if (this.mocksMap.get(keyInUse).containsKey(i) == false) {
+          throw new InvalidOperationException(String.format(MISSING_RETURN_VALUE_FOR_NTH_TIME_CALLING, new List<String>{ String.valueOf(i) }));
+        }
+      }
+    }
     this.saveArguments(listOfParamNames, listOfArgs, keyInUse);
 
-    Object returnValue = this.mocksMap.get(keyInUse);
+    Object returnValue = this.mocksMap.get(keyInUse)?.get(countToUse);
 
     if (this.mutatorMap.containsKey(keyInUse)) {
       for (Mutator m : this.mutatorMap.get(keyInUse)) {
@@ -228,13 +245,24 @@ public with sharing class UniversalMocker implements System.StubProvider {
     }
   }
 
+  private void isCalledForTheNthTime(Integer n) {
+    if (n < 1) {
+      throw new IllegalArgumentException('`isCalledForTheNthTime` is only valid for n >= 1');
+    }
+    this.setResultsForCallingNTimes = true;
+    this.onTheNthTime = n;
+  }
+
   private void thenReturnVoid() {
     this.thenReturn(null);
   }
 
   private void thenReturn(Object returnObject) {
     String key = this.getCurrentKey();
-    this.mocksMap.put(key, returnObject);
+    if (this.mocksMap.containsKey(key) == false) {
+      this.mocksMap.put(key, new Map<Integer, Object>());
+    }
+    this.mocksMap.get(key).put(this.onTheNthTime, returnObject);
     if (!this.callCountsMap.containsKey(key)) {
       this.callCountsMap.put(key, 0);
     }

--- a/force-app/main/default/classes/example/AccountDBService.cls
+++ b/force-app/main/default/classes/example/AccountDBService.cls
@@ -11,7 +11,7 @@ public with sharing class AccountDBService {
     return [SELECT Name FROM Account WHERE Name = :accountName];
   }
 
-  public void doInsert(Account acct) {
-    insert acct;
+  public Database.SaveResult doInsert(Account acct) {
+    return Database.insert(acct);
   }
 }

--- a/force-app/main/default/classes/example/AccountDomain.cls
+++ b/force-app/main/default/classes/example/AccountDomain.cls
@@ -1,4 +1,8 @@
 public with sharing class AccountDomain {
+  public static final String INITAL_UNSUCCESS_MESSAGE = 'Initial Result Unsuccessful';
+  public static final String PUBLIC_STRING = 'public';
+  public static final String SECOND_UNSUCCESS_MESSAGE = 'Second Result Unsuccessful';
+
   AccountDBService acctService = null;
 
   public AccountDomain(AccountDBService svc) {
@@ -14,8 +18,22 @@ public with sharing class AccountDomain {
   }
 
   public void createPublicAccount(String acctName) {
-    Account acct = new Account(Name = acctName, Ownership = 'Public');
+    Account acct = new Account(Name = acctName, Ownership = PUBLIC_STRING);
     this.acctService.doInsert(acct);
+  }
+
+  public void createTwoPublicAccounts(String acctName) {
+    Account acct = new Account(Name = acctName, Ownership = PUBLIC_STRING);
+    Database.SaveResult initialResult = this.acctService.doInsert(acct);
+    if (initialResult.isSuccess() == false) {
+      throw new AccountDomainException(INITAL_UNSUCCESS_MESSAGE);
+    }
+
+    Account acct2 = new Account(Name = 'Copy of ' + acctName, Ownership = PUBLIC_STRING);
+    Database.SaveResult copyResult = this.acctService.doInsert(acct2);
+    if (copyResult.isSuccess() == false) {
+      throw new AccountDomainException(SECOND_UNSUCCESS_MESSAGE);
+    }
   }
 
   public Account[] getMatchingAccounts(String attribute) {
@@ -24,5 +42,8 @@ public with sharing class AccountDomain {
     } else {
       return this.acctService.getMatchingAccounts(attribute);
     }
+  }
+
+  public class AccountDomainException extends Exception {
   }
 }

--- a/force-app/main/default/classes/example/AccountDomainTest.cls
+++ b/force-app/main/default/classes/example/AccountDomainTest.cls
@@ -1,5 +1,18 @@
 @IsTest
 public with sharing class AccountDomainTest {
+  private static final String ACCOUNT_ID_IS_NULL_AFTER_INSERT = 'Account Id is null after insert';
+  private static final String ACCOUNT_WITH_MATCHING_NAME = 'Account with matching name';
+  private static final String ACCT = 'acct';
+  private static final String ACME = 'Acme';
+  private static final String DO_INSERT = 'doInsert';
+  private static final String GET_MATCHING_ACCOUNTS = 'getMatchingAccounts';
+  private static final String GET_ONE_ACCOUNT = 'getOneAccount';
+  private static final String MOCK_ACCOUNT = 'Mock Account';
+  private static final String MOCK_EXCEPTION = 'Mock exception';
+  private static final String MOCKED_ACCOUNT_ID = '001000000000001';
+  private static final String MOCKED_DUMMY_METHOD = 'mockedDummyMethod';
+  private static final String MOCKED_EXCEPTION_WAS_NOT_THROWN = 'Mocked exception was not thrown';
+
   private static final UniversalMocker mockService;
   private static final AccountDBService mockServiceStub;
   private static final AccountDomain sut; // system under test
@@ -13,8 +26,8 @@ public with sharing class AccountDomainTest {
   @IsTest
   public static void it_should_return_one_account() {
     //setup
-    String mockedMethodName = 'getOneAccount';
-    Account mockAccount = new Account(Name = 'Mock Account');
+    String mockedMethodName = GET_ONE_ACCOUNT;
+    Account mockAccount = new Account(Name = MOCK_ACCOUNT);
 
     mockService.when(mockedMethodName).thenReturn(mockAccount);
 
@@ -31,27 +44,27 @@ public with sharing class AccountDomainTest {
   @IsTest
   public static void it_should_create_a_public_account() {
     //setup
-    String mockedMethodName = 'doInsert';
+    String mockedMethodName = DO_INSERT;
 
     //test
     Test.startTest();
-    sut.createPublicAccount('Mock Account');
+    sut.createPublicAccount(MOCK_ACCOUNT);
     Test.stopTest();
 
     //verify
-    Account newAccount = (Account) mockService.forMethod(mockedMethodName).andInvocationNumber(0).getValueOf('acct');
-    system.assertEquals('Mock Account', newAccount.Name);
-    system.assertEquals('Public', newAccount.Ownership);
+    Account newAccount = (Account) mockService.forMethod(mockedMethodName).andInvocationNumber(0).getValueOf(ACCT);
+    system.assertEquals(MOCK_ACCOUNT, newAccount.Name);
+    system.assertEquals(AccountDomain.PUBLIC_STRING, newAccount.Ownership);
   }
 
   @IsTest
   public static void it_should_verify_call_counts_correctly() {
     //setup
-    String mockedMethodName = 'getOneAccount';
-    Account mockAccount = new Account(Name = 'Mock Account');
+    String mockedMethodName = GET_ONE_ACCOUNT;
+    Account mockAccount = new Account(Name = MOCK_ACCOUNT);
 
     mockService.when(mockedMethodName).thenReturn(mockAccount);
-    mockService.when('mockedDummyMethod').thenReturn(null);
+    mockService.when(MOCKED_DUMMY_METHOD).thenReturn(null);
 
     //test
     Test.startTest();
@@ -66,25 +79,25 @@ public with sharing class AccountDomainTest {
     mockService.assertThat().method(mockedMethodName).wasCalled(2);
     mockService.assertThat().method(mockedMethodName).wasCalled(2, UniversalMocker.Times.OR_LESS);
     mockService.assertThat().method(mockedMethodName).wasCalled(3, UniversalMocker.Times.OR_LESS);
-    mockService.assertThat().method('mockedDummyMethod').wasNeverCalled();
+    mockService.assertThat().method(MOCKED_DUMMY_METHOD).wasNeverCalled();
     mockService.assertThat().method('nonMockedDummyMethod').wasNeverCalled();
   }
 
   @IsTest
   public static void it_should_call_overloaded_methods_correctly() {
     //setup
-    String mockedMethodName = 'getMatchingAccounts';
+    String mockedMethodName = GET_MATCHING_ACCOUNTS;
     Account acctOne = new Account(Name = 'Account with matching Id');
-    Account acctTwo = new Account(Name = 'Account with matching name');
+    Account acctTwo = new Account(Name = ACCOUNT_WITH_MATCHING_NAME);
 
     mockService.when(mockedMethodName).withParamTypes(new List<Type>{ Id.class }).thenReturn(new List<Account>{ acctOne });
     mockService.when(mockedMethodName).withParamTypes(new List<Type>{ String.class }).thenReturn(new List<Account>{ acctTwo });
 
     //test
     Test.startTest();
-    Id mockAccountId = '001000000000001';
+    Id mockAccountId = MOCKED_ACCOUNT_ID;
     List<Account> acctsWithMatchingId = sut.getMatchingAccounts(mockAccountId);
-    List<Account> acctsWithMatchingName = sut.getMatchingAccounts('Account with matching name');
+    List<Account> acctsWithMatchingName = sut.getMatchingAccounts(ACCOUNT_WITH_MATCHING_NAME);
     Test.stopTest();
 
     //verify
@@ -97,7 +110,7 @@ public with sharing class AccountDomainTest {
       .getValueOf('accountName');
 
     System.assertEquals(mockAccountId, accountIdParam);
-    System.assertEquals('Account with matching name', acctNameParam);
+    System.assertEquals(ACCOUNT_WITH_MATCHING_NAME, acctNameParam);
     System.assertEquals(acctOne.Name, acctsWithMatchingId[0].Name);
     System.assertEquals(acctTwo.Name, acctsWithMatchingName[0].Name);
   }
@@ -105,8 +118,8 @@ public with sharing class AccountDomainTest {
   @IsTest
   public static void it_should_throw_mock_exception() {
     //setup
-    String mockedMethodName = 'doInsert';
-    String mockExceptionMessage = 'Mock exception';
+    String mockedMethodName = DO_INSERT;
+    String mockExceptionMessage = MOCK_EXCEPTION;
     AuraHandledException mockException = new AuraHandledException(mockExceptionMessage);
     /*https://salesforce.stackexchange.com/questions/122657/testing-aurahandledexceptions*/
     mockException.setMessage(mockExceptionMessage);
@@ -117,7 +130,7 @@ public with sharing class AccountDomainTest {
     Test.startTest();
     boolean hasException = false;
     try {
-      sut.createPublicAccount('Mock Account');
+      sut.createPublicAccount(MOCK_ACCOUNT);
     } catch (AuraHandledException ex) {
       System.assertEquals(mockExceptionMessage, ex.getMessage());
       hasException = true;
@@ -126,7 +139,7 @@ public with sharing class AccountDomainTest {
 
     //verify
     mockService.assertThat().method(mockedMethodName).wasCalled(1);
-    System.assert(hasException, 'Mocked exception was not thrown');
+    System.assert(hasException, MOCKED_EXCEPTION_WAS_NOT_THROWN);
   }
 
   @IsTest
@@ -140,8 +153,8 @@ public with sharing class AccountDomainTest {
 
   @IsTest
   public static void it_should_track_call_counts_across_queueables() {
-    String mockedMethodName = 'doInsert';
-    String mockExceptionMessage = 'Mock exception';
+    String mockedMethodName = DO_INSERT;
+    String mockExceptionMessage = MOCK_EXCEPTION;
     UniversalMocker.Mutator dmlMutatorInstance = new DMLMutator();
 
     mockService.when(mockedMethodName).mutateWith(dmlMutatorInstance).thenReturnVoid();
@@ -154,14 +167,14 @@ public with sharing class AccountDomainTest {
 
     //verify
     mockService.assertThat().method(mockedMethodName).wasCalled(1);
-    Account acct = (Account) mockService.forMethod(mockedMethodName).getValueOf('acct');
-    System.assertNotEquals(null, acct.Id, 'Account Id is null after insert');
+    Account acct = (Account) mockService.forMethod(mockedMethodName).getValueOf(ACCT);
+    System.assertNotEquals(null, acct.Id, ACCOUNT_ID_IS_NULL_AFTER_INSERT);
   }
 
   @IsTest
   public static void it_should_track_call_counts_with_batchables() {
-    String mockedMethodName = 'getOneAccount';
-    Account mockAccount = new Account(Name = 'Mock Account');
+    String mockedMethodName = GET_ONE_ACCOUNT;
+    Account mockAccount = new Account(Name = MOCK_ACCOUNT);
     mockService.when(mockedMethodName).thenReturn(mockAccount);
 
     AccountsBatch batchableSut = new AccountsBatch(sut);
@@ -178,8 +191,8 @@ public with sharing class AccountDomainTest {
   @IsTest
   public static void it_should_mutate_arguments() {
     //setup
-    String mockedMethodName = 'doInsert';
-    String mockExceptionMessage = 'Mock exception';
+    String mockedMethodName = DO_INSERT;
+    String mockExceptionMessage = MOCK_EXCEPTION;
     UniversalMocker.Mutator dmlMutatorInstance = new DMLMutator();
 
     mockService.when(mockedMethodName).mutateWith(dmlMutatorInstance).thenReturnVoid();
@@ -188,7 +201,7 @@ public with sharing class AccountDomainTest {
     Test.startTest();
     boolean hasException = false;
     try {
-      sut.createPublicAccount('Mock Account');
+      sut.createPublicAccount(MOCK_ACCOUNT);
     } catch (AuraHandledException ex) {
       System.assertEquals(mockExceptionMessage, ex.getMessage());
       hasException = true;
@@ -197,19 +210,133 @@ public with sharing class AccountDomainTest {
 
     //verify
     mockService.assertThat().method(mockedMethodName).wasCalled(1);
-    System.assert(!hasException, 'Mocked exception was not thrown');
-    Account acct = (Account) mockService.forMethod('doInsert').getValueOf('acct');
-    System.assertNotEquals(null, acct.Id, 'Account Id is null after insert');
+    System.assert(!hasException, MOCKED_EXCEPTION_WAS_NOT_THROWN);
+    Account acct = (Account) mockService.forMethod(DO_INSERT).getValueOf(ACCT);
+    System.assertNotEquals(null, acct.Id, ACCOUNT_ID_IS_NULL_AFTER_INSERT);
+  }
+
+  @IsTest
+  private static void create_two_accounts_should_succeed_if_both_are_successful() {
+    //setup
+    String mockedMethodName = DO_INSERT;
+    Database.SaveResult mockedSaveResult = generateSaveResult(true);
+    mockService.when(mockedMethodName).thenReturn(mockedSaveResult);
+    AccountDomain.AccountDomainException myException;
+
+    //test
+    Test.startTest();
+    try {
+      sut.createTwoPublicAccounts(ACME);
+    } catch (AccountDomain.AccountDomainException e) {
+      myException = e;
+    }
+    Test.stopTest();
+
+    //verify
+    System.assertEquals(null, myException, 'An exception should be thrown because the Database.SaveResult is not successful');
+  }
+
+  @IsTest
+  private static void create_two_accounts_should_throw_initial_exception_if_initial_is_unsuccessful() {
+    //setup
+    String mockedMethodName = DO_INSERT;
+    Database.SaveResult mockedSaveResult = generateSaveResult(false);
+    mockService.when(mockedMethodName).isCalledForTheNthTime(1).thenReturn(mockedSaveResult);
+    AccountDomain.AccountDomainException myException;
+
+    //test
+    Test.startTest();
+    try {
+      sut.createTwoPublicAccounts(ACME);
+    } catch (AccountDomain.AccountDomainException e) {
+      myException = e;
+    }
+    Test.stopTest();
+
+    //verify
+    System.assertNotEquals(null, myException, 'An exception should be thrown because the Database.SaveResult is not successful');
+    System.assertEquals(true, myException.getMessage() == AccountDomain.INITAL_UNSUCCESS_MESSAGE, 'The exception should be for the initial SaveResult');
+  }
+
+  @IsTest
+  private static void create_two_accounts_should_throw_copy_exception_if_second_is_unsuccessful() {
+    //setup
+    String mockedMethodName = DO_INSERT;
+    mockService.when(mockedMethodName).isCalledForTheNthTime(1).thenReturn(generateSaveResult(true));
+    mockService.when(mockedMethodName).isCalledForTheNthTime(2).thenReturn(generateSaveResult(false));
+    AccountDomain.AccountDomainException myException;
+
+    //test
+    Test.startTest();
+    try {
+      sut.createTwoPublicAccounts(ACME);
+    } catch (AccountDomain.AccountDomainException e) {
+      myException = e;
+    }
+    Test.stopTest();
+
+    //verify
+    System.assertNotEquals(null, myException, 'An exception should be thrown because the Database.SaveResult is not successful');
+    System.assertEquals(true, myException.getMessage() == AccountDomain.SECOND_UNSUCCESS_MESSAGE, 'The exception should be for the second SaveResult');
+  }
+
+  @IsTest
+  private static void setting_is_called_for_the_nth_time_for_negative_numbers_should_cause_illegal_argument() {
+    //setup
+    String mockedMethodName = DO_INSERT;
+    IllegalArgumentException myException;
+
+    //test
+    Test.startTest();
+    try {
+      mockService.when(mockedMethodName).isCalledForTheNthTime(-1).thenReturn(generateSaveResult(true));
+    } catch (IllegalArgumentException e) {
+      myException = e;
+    }
+    Test.stopTest();
+
+    //verify
+    System.assertNotEquals(null, myException, 'An exception should be thrown because `isCalledForTheNthTime` is not valid for n=-1');
+  }
+
+  @IsTest
+  private static void skipping_indicies_when_setting_is_called_for_the_nth_time_should_cause_invalid_operation() {
+    //setup
+    String mockedMethodName = DO_INSERT;
+    mockService.when(mockedMethodName).isCalledForTheNthTime(1).thenReturn(generateSaveResult(true));
+    mockService.when(mockedMethodName).isCalledForTheNthTime(3).thenReturn(generateSaveResult(false));
+    UniversalMocker.InvalidOperationException myException;
+
+    //test
+    Test.startTest();
+    try {
+      sut.createTwoPublicAccounts(ACME);
+    } catch (UniversalMocker.InvalidOperationException e) {
+      myException = e;
+    }
+    Test.stopTest();
+
+    //verify
+    System.assertNotEquals(null, myException, 'An exception should be thrown because the index of 2 was skipped');
+    System.assertEquals(
+      String.format(UniversalMocker.MISSING_RETURN_VALUE_FOR_NTH_TIME_CALLING, new List<String>{ String.valueOf(2) }),
+      myException.getMessage(),
+      'The exceptions\'s message is improperly formatted'
+    );
+  }
+
+  private static Database.SaveResult generateSaveResult(Boolean success) {
+    return (Database.SaveResult) JSON.deserialize(JSON.serialize(new Map<String, Object>{ 'success' => success }, true), Database.SaveResult.class);
   }
 
   @IsTest
   public static void dummy_test_for_db_service() {
     AccountDBService dbSvc = new AccountDBService();
-    Account a = new Account(Name = 'Acme');
+    Account a = new Account(Name = ACME);
     dbSvc.doInsert(a);
     dbSvc.getOneAccount();
-    dbSvc.getMatchingAccounts(Id.valueOf('001000000000001'));
-    dbSvc.getMatchingAccounts('Acme');
+    dbSvc.getMatchingAccounts(Id.valueOf(MOCKED_ACCOUNT_ID));
+    dbSvc.getMatchingAccounts(ACME);
   }
 
   public class DMLMutator implements UniversalMocker.Mutator {

--- a/force-app/main/default/classes/example/AccountDomainTest.cls
+++ b/force-app/main/default/classes/example/AccountDomainTest.cls
@@ -233,7 +233,7 @@ public with sharing class AccountDomainTest {
     Test.stopTest();
 
     //verify
-    System.assertEquals(null, myException, 'An exception should be thrown because the Database.SaveResult is not successful');
+    System.assertEquals(null, myException, 'An exception should not be thrown because both of the Database.SaveResult were successful');
   }
 
   @IsTest


### PR DESCRIPTION
- Enabled fluent interface for calling `isCalledForTheNthTime` to define different mocked results for repeated method calls
- Added examples and tests in `AccountDomainTest`
- Retained backwards compatibility with existing implementations
- Cleaned up magic strings
- Added to .gitIgnore

example:
```
mockService.when(mockedMethodName).isCalledForTheNthTime(1).thenReturn(true);
mockService.when(mockedMethodName).isCalledForTheNthTime(2).thenReturn(false);
```